### PR TITLE
Fixed the code which checked for GPU details

### DIFF
--- a/gretch.sh
+++ b/gretch.sh
@@ -91,11 +91,9 @@ fi
 
 
 #GPU
-if [ "AMD 8370D" ]; then
-    printf "GPU:%-7s" ; lspci | grep 'VGA' | cut -d "." -f 3 | tr -d "[]" | tr '/' ' ' | sed 's/Richland //' #short
-else
-    printf "GPU:%-7s" ; lspci | grep 'VGA' | cut -d ":" -f 3 | tr -d "[]" #long output
-fi
+printf "GPU:%-7s" 
+lspci | grep -E 'VGA|3D' | cut -d ':' -f 3 | sed 's/^ //'
+
 
 
 #memory (in mebibytes)

--- a/out.txt
+++ b/out.txt
@@ -91,13 +91,13 @@ fi
 
 
 #GPU
-printf "GPU:%-8s" 
-lspci | grep -E 'VGA|3D' | cut -d ':' -f 3 | sed 's/^ //' | awk '{$1=$1}1'
+printf "GPU:%-7s" 
+lspci | grep -E 'VGA|3D' | cut -d ':' -f 3 | sed 's/^ //'
 
 #VRAM
 vram=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null)
 if [ -n "$vram" ]; then
-    printf "VRAM:%-7s%s MiB\n" "" "$vram"
+    printf "VRAM:     $vram MiB\n"
 fi
 
 


### PR DESCRIPTION
Fixed the code which checked for GPU details. Now the output from lspci is formatted clearly and printed on to the screen.
<img width="1402" height="762" alt="GPU" src="https://github.com/user-attachments/assets/dd7618bf-7e56-484a-b123-57445099fc9b" />
