### PR TITLE
Correct shell detection using $SHELL instead of /proc/$$/exe (resolves #5)

### DIFF
--- a/gretch.sh
+++ b/gretch.sh
@@ -54,10 +54,9 @@ fi
 
 
 #Shell
-shell=bash
-var1=$(basename $(readlink /proc/$$/exe))
-var2=$(echo "$BASH_VERSION" | cut -c 1-6) 
-if [[ $shell == "bash" ]]; then
+var1=$(basename "$SHELL") 
+if [[ $var1 == "bash" ]]; then
+    var2=$(echo "$BASH_VERSION" | cut -c 1-6)
     printf "%-11s %s %s\n" "Shell:" "$var1" "$var2" 
 else
     printf "%-11s %s\n" "Shell:" "$var1"


### PR DESCRIPTION
The program now correctly identifies the login shell. Previously, the code always printed bash as the shell because the script is executed by bash (#!/bin/bash). Moved var2 inside the if block as it is only needed if the shell is bash. Removed the hardcoding (shell=bash).

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/88afd88f-7894-4e8b-93c5-43102f92ccc7" />